### PR TITLE
Fix datetime module reference in utils

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,5 @@
 import json
-import datetime
+import datetime as dt
 from datetime import datetime, date, timedelta
 from models import TaxBracket, Employee, Payroll, PayrollItem, SalaryConfiguration
 
@@ -468,7 +468,7 @@ def count_working_days(start_date, end_date):
             working_days += 1
         
         # Move to next day
-        current_date += datetime.timedelta(days=1)
+        current_date += dt.timedelta(days=1)
     
     return working_days
 
@@ -486,18 +486,18 @@ def calculate_proration_factor(start_date, end_date, month=None, year=None):
         Float between 0 and 1 representing the proration factor
     """
     # Use current month and year if not specified
-    today = datetime.date.today()
+    today = dt.date.today()
     if month is None:
         month = today.month
     if year is None:
         year = today.year
     
     # Get the first and last day of the specified month
-    first_day = datetime.date(year, month, 1)
+    first_day = dt.date(year, month, 1)
     if month == 12:
-        last_day = datetime.date(year, 12, 31)
+        last_day = dt.date(year, 12, 31)
     else:
-        last_day = datetime.date(year, month + 1, 1) - datetime.timedelta(days=1)
+        last_day = dt.date(year, month + 1, 1) - dt.timedelta(days=1)
     
     # Count total working days in the month
     total_working_days = count_working_days(first_day, last_day)


### PR DESCRIPTION
## Summary
- rename datetime module import to avoid shadowing the datetime class
- use the new alias when calling date and timedelta functions

## Testing
- `python -m py_compile utils.py`
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_68409265559c83339636e91ee5907ae2