### PR TITLE
Store payroll item breakdowns as JSON objects

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,8 +78,10 @@ def create_app(config_class=Config):
     import json
     @app.template_filter('from_json')
     def from_json_filter(value):
-        """Convert a JSON string to a Python dictionary."""
-        return json.loads(value) if value else {}
+        """Ensure a JSON value is returned as a dictionary."""
+        if isinstance(value, str):
+            return json.loads(value) if value else {}
+        return value or {}
         
     # Add company settings to all templates
     @app.context_processor

--- a/migrate_payroll_item_json.py
+++ b/migrate_payroll_item_json.py
@@ -1,0 +1,40 @@
+from app import create_app, db
+from models import PayrollItem
+import json
+
+
+def convert_json_fields():
+    app = create_app()
+    with app.app_context():
+        items = PayrollItem.query.all()
+        converted = 0
+        for item in items:
+            changed = False
+            if isinstance(item.allowances, str):
+                try:
+                    item.allowances = json.loads(item.allowances) if item.allowances else {}
+                    changed = True
+                except Exception:
+                    pass
+            if isinstance(item.deductions, str):
+                try:
+                    item.deductions = json.loads(item.deductions) if item.deductions else {}
+                    changed = True
+                except Exception:
+                    pass
+            if isinstance(item.tax_details, str):
+                try:
+                    item.tax_details = json.loads(item.tax_details) if item.tax_details else {}
+                    changed = True
+                except Exception:
+                    pass
+            if changed:
+                db.session.add(item)
+                converted += 1
+        if converted:
+            db.session.commit()
+        print(f"Converted {converted} payroll items")
+
+
+if __name__ == "__main__":
+    convert_json_fields()

--- a/routes/payroll.py
+++ b/routes/payroll.py
@@ -212,10 +212,10 @@ def view_payroll_item(id):
     # Get all adjustments for this payroll item
     adjustments = PayrollAdjustment.query.filter_by(payroll_item_id=id).order_by(PayrollAdjustment.date_created.desc()).all()
     
-    # Parse JSON fields from the payroll item
-    allowances_dict = json.loads(payroll_item.allowances) if payroll_item.allowances else {}
-    deductions_dict = json.loads(payroll_item.deductions) if payroll_item.deductions else {}
-    tax_details_dict = json.loads(payroll_item.tax_details) if payroll_item.tax_details else {}
+    # JSON fields are stored as dictionaries
+    allowances_dict = payroll_item.allowances or {}
+    deductions_dict = payroll_item.deductions or {}
+    tax_details_dict = payroll_item.tax_details or {}
     
     # Create a new adjustment form if the payroll is in an editable state
     adjustment_form = None

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,3 @@
-import json
 import datetime as dt
 from datetime import datetime, date, timedelta
 from models import TaxBracket, Employee, Payroll, PayrollItem, SalaryConfiguration
@@ -247,19 +246,19 @@ def process_payroll(payroll_id):
             other_deductions=0.0,
             net_pay=monthly_net_pay,
             is_adjusted=False,
-            allowances=json.dumps({
+            allowances={
                 'Housing Allowance': housing_allowance,
                 'Transport Allowance': transport_allowance,
                 'Utility Allowance': utility_allowance,
                 'Meal Allowance': meal_allowance,
                 'Clothing Allowance': clothing_allowance
-            }),
-            deductions=json.dumps({
+            },
+            deductions={
                 'Pension': monthly_pension,
                 'NHF': monthly_nhf,
                 'PAYE Tax': monthly_tax
-            }),
-            tax_details=json.dumps({
+            },
+            tax_details={
                 'Annual Basic Salary': annual_basic,
                 'Annual Gross Income': annual_gross,
                 'Consolidated Relief': consolidated_relief,
@@ -267,7 +266,7 @@ def process_payroll(payroll_id):
                 'Annual Tax': annual_tax,
                 'Monthly Tax': monthly_tax,
                 'Tax Brackets': tax_details
-            })
+            }
         )
         
         # Add to database
@@ -324,10 +323,10 @@ def generate_payslip_data(payroll_item_id):
     # Get any adjustments for this payroll item
     adjustments = PayrollAdjustment.query.filter_by(payroll_item_id=payroll_item_id).all()
     
-    # Parse JSON fields
-    allowances = json.loads(payroll_item.allowances)
-    deductions = json.loads(payroll_item.deductions)
-    tax_details = json.loads(payroll_item.tax_details)
+    # Fields are stored as JSON in the database and returned as dictionaries
+    allowances = payroll_item.allowances or {}
+    deductions = payroll_item.deductions or {}
+    tax_details = payroll_item.tax_details or {}
     
     # Calculate adjustment totals by type
     bonuses = sum(adj.amount for adj in adjustments if adj.adjustment_type == 'bonus')


### PR DESCRIPTION
## Summary
- store payroll item allowances, deductions and tax details as Python dicts
- treat stored JSON fields as dicts when generating views
- update Jinja `from_json` filter for either strings or dicts
- migration script to convert existing payroll items

## Testing
- `python -m py_compile utils.py routes/payroll.py app.py migrate_payroll_item_json.py`

------
https://chatgpt.com/codex/tasks/task_e_6840aa6c849483338cbc2463d5690f84